### PR TITLE
refactor: replace runtime unwrap/expect with structured error handling

### DIFF
--- a/crates/rgz-transport/src/discovery/discovery.rs
+++ b/crates/rgz-transport/src/discovery/discovery.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, bail};
 use std::collections::{HashMap, HashSet};
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-use std::sync::{Arc, Mutex};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::{env, io};
 use tokio::net::UdpSocket;
 use tokio::select;
@@ -35,6 +35,12 @@ struct SendMsg {
 }
 
 type DiscoveryCallbackType = Box<dyn Fn(DiscoveryPublisher) + Send + Sync>;
+
+fn lock_mutex<'a, T>(mutex: &'a Mutex<T>, name: &str) -> Result<MutexGuard<'a, T>> {
+    mutex
+        .lock()
+        .map_err(|err| anyhow::anyhow!("Failed to lock {}: {}", name, err))
+}
 
 pub(crate) struct Discovery {
     // Discovery wire protocol version.
@@ -88,7 +94,13 @@ impl Discovery {
     pub(crate) fn new(p_uuid: &str, ip: &str, port: u16, verbose: bool) -> Self {
         let p_uuid = p_uuid.to_string();
         let ip = ip.to_string();
-        let multicast_group = ip.parse::<Ipv4Addr>().unwrap();
+        let multicast_group = ip.parse::<Ipv4Addr>().unwrap_or_else(|err| {
+            warn!(
+                "Invalid discovery multicast IP [{}]: {}. Falling back to 239.255.0.7",
+                ip, err
+            );
+            Ipv4Addr::new(239, 255, 0, 7)
+        });
         let multicast_addr = SocketAddrV4::new(multicast_group, port);
         let mut host_addr = Ipv4Addr::new(127, 0, 0, 1);
         if let Ok(host) = net_utils::determine_host() {
@@ -99,8 +111,12 @@ impl Discovery {
         let mut host_interfaces: Vec<Ipv4Addr> = Vec::new();
         if let Ok(gz_ip) = env::var("GZ_IP") {
             if !gz_ip.is_empty() {
-                let ip = gz_ip.parse::<Ipv4Addr>().unwrap();
-                host_interfaces.push(ip);
+                match gz_ip.parse::<Ipv4Addr>() {
+                    Ok(ip) => host_interfaces.push(ip),
+                    Err(err) => {
+                        warn!("Invalid GZ_IP [{}]: {}", gz_ip, err);
+                    }
+                }
             }
         } else {
             // Get the list of network interfaces in this host.
@@ -136,45 +152,49 @@ impl Discovery {
     where
         F: Fn(DiscoveryPublisher) + Send + Sync + 'static,
     {
-        self.connection_cb
-            .lock()
-            .unwrap()
-            .replace(Box::new(callback));
+        if let Ok(mut cb) = self.connection_cb.lock() {
+            cb.replace(Box::new(callback));
+        } else {
+            error!("Failed to lock connection_cb");
+        }
     }
 
     pub(crate) fn set_disconnection_cb<F>(&mut self, callback: F)
     where
         F: Fn(DiscoveryPublisher) + Send + Sync + 'static,
     {
-        self.disconnection_cb
-            .lock()
-            .unwrap()
-            .replace(Box::new(callback));
+        if let Ok(mut cb) = self.disconnection_cb.lock() {
+            cb.replace(Box::new(callback));
+        } else {
+            error!("Failed to lock disconnection_cb");
+        }
     }
 
     pub(crate) fn set_registration_cb<F>(&mut self, callback: F)
     where
         F: Fn(DiscoveryPublisher) + Send + Sync + 'static,
     {
-        self.registration_cb
-            .lock()
-            .unwrap()
-            .replace(Box::new(callback));
+        if let Ok(mut cb) = self.registration_cb.lock() {
+            cb.replace(Box::new(callback));
+        } else {
+            error!("Failed to lock registration_cb");
+        }
     }
 
     pub(crate) fn set_unregistration_cb<F>(&mut self, callback: F)
     where
         F: Fn(DiscoveryPublisher) + Send + Sync + 'static,
     {
-        self.unregistration_cb
-            .lock()
-            .unwrap()
-            .replace(Box::new(callback));
+        if let Ok(mut cb) = self.unregistration_cb.lock() {
+            cb.replace(Box::new(callback));
+        } else {
+            error!("Failed to lock unregistration_cb");
+        }
     }
 
     pub fn advertise(&self, discovery_publisher: DiscoveryPublisher) -> Result<()> {
         {
-            let mut store = self.discovery_store.lock().unwrap();
+            let mut store = lock_mutex(&self.discovery_store, "discovery_store")?;
             if let Err(e) = store.add_publisher(discovery_publisher.clone()) {
                 bail!("Failed to add publisher: {}", e);
             }
@@ -199,7 +219,7 @@ impl Discovery {
 
     pub fn unadvertise(&self, topic: &str, n_uuid: &str) -> Result<()> {
         let publisher = {
-            let mut store = self.discovery_store.lock().unwrap();
+            let mut store = lock_mutex(&self.discovery_store, "discovery_store")?;
             if let Some(p) = store.publisher(topic, &self.p_uuid, n_uuid) {
                 let publisher = p.clone();
                 store.del_publisher_by_node(topic, &self.p_uuid, n_uuid)?;
@@ -242,7 +262,7 @@ impl Discovery {
             })?;
 
             let publishers = {
-                let store = self.discovery_store.lock().unwrap();
+                let store = lock_mutex(&self.discovery_store, "discovery_store")?;
                 let mut v = vec![];
                 for p in store.publishers(Some(topic), None, None) {
                     v.push(p.clone())
@@ -251,7 +271,7 @@ impl Discovery {
             };
 
             for p in publishers {
-                if let Some(cb) = self.connection_cb.lock().unwrap().as_ref() {
+                if let Some(cb) = lock_mutex(&self.connection_cb, "connection_cb")?.as_ref() {
                     cb(p.clone());
                 }
             }
@@ -284,7 +304,13 @@ impl Discovery {
 
     // Get all the publishers' information known for a given topic.
     pub fn publishers(&self, topic: &str) -> Option<Vec<DiscoveryPublisher>> {
-        let store = self.discovery_store.lock().unwrap();
+        let store = match self.discovery_store.lock() {
+            Ok(store) => store,
+            Err(err) => {
+                error!("Failed to lock discovery_store: {}", err);
+                return None;
+            }
+        };
         let publishers: Vec<DiscoveryPublisher> = store
             .publishers(Some(topic), None, None)
             .into_iter()
@@ -300,13 +326,17 @@ impl Discovery {
 
     // Get the list of topics currently advertised in the network.
     pub fn topic_list(&self) -> Vec<String> {
-        self.discovery_store
-            .lock()
-            .unwrap()
-            .topic_list()
-            .into_iter()
-            .map(|s| s.to_string())
-            .collect()
+        match self.discovery_store.lock() {
+            Ok(store) => store
+                .topic_list()
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
+            Err(err) => {
+                error!("Failed to lock discovery_store: {}", err);
+                Vec::new()
+            }
+        }
     }
 
     pub fn host_addr(&self) -> &Ipv4Addr {
@@ -314,9 +344,10 @@ impl Discovery {
     }
 
     pub fn print_current_state(&self) {
-        {
-            let store = self.discovery_store.lock().unwrap();
+        if let Ok(store) = self.discovery_store.lock() {
             store.print();
+        } else {
+            error!("Failed to lock discovery_store for print_current_state");
         }
     }
 
@@ -427,7 +458,7 @@ impl Discovery {
         for net_iface in self.host_interfaces.iter() {
             if let Err(_err) = socket.join_multicast_v4(self.multicast_addr.ip(), net_iface) {
                 if net_iface == &self.host_addr {
-                    let addr = "127.0.0.1:0".parse::<SocketAddrV4>().unwrap();
+                    let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
                     socket.join_multicast_v4(self.multicast_addr.ip(), addr.ip())?;
                     error!(
                         "Did you set the environment variable GZ_IP with a correct IP address? "
@@ -550,7 +581,10 @@ impl DiscoveryInner {
         if addr.is_ipv6() {
             bail!("Received an IPv6 discovery message.");
         }
-        let from_ip: Ipv4Addr = addr.ip().to_string().parse().unwrap();
+        let from_ip = match addr.ip() {
+            IpAddr::V4(ip) => ip,
+            IpAddr::V6(_) => bail!("Received an IPv6 discovery message."),
+        };
         let msg = match discovery_msg_decode(&mut rcv_str, len) {
             Ok(msg) => msg,
             Err(e) => {
@@ -577,7 +611,7 @@ impl DiscoveryInner {
 
         // Re-advertise topics that are advertised inside this process.
         let publishers = {
-            let store = self.discovery_store.lock().unwrap();
+            let store = lock_mutex(&self.discovery_store, "discovery_store")?;
             let mut v = vec![];
             for p in store.publishers_by_process(&self.p_uuid) {
                 v.push(p.clone())
@@ -596,7 +630,7 @@ impl DiscoveryInner {
     async fn update_activity(&self) -> Result<()> {
         // Identify inactive processes and remove them from the activity map.
         let inactive_processes = {
-            let mut activity = self.activity.lock().unwrap();
+            let mut activity = lock_mutex(&self.activity, "activity")?;
             let mut v = vec![];
             activity.retain(|process_uuid, last_activity| {
                 if last_activity.elapsed().as_millis() > self.silence_interval as u128 {
@@ -612,7 +646,7 @@ impl DiscoveryInner {
 
         // Remove publishers related to inactive processes.
         let disconnect_processes = {
-            let mut store = self.discovery_store.lock().unwrap();
+            let mut store = lock_mutex(&self.discovery_store, "discovery_store")?;
             inactive_processes
                 .into_iter()
                 .filter(|process_uuid| {
@@ -627,7 +661,7 @@ impl DiscoveryInner {
         };
 
         // Trigger the disconnection callback.
-        if let Some(cb) = self.disconnection_cb.lock().unwrap().as_ref() {
+        if let Some(cb) = lock_mutex(&self.disconnection_cb, "disconnection_cb")?.as_ref() {
             for process_uuid in &disconnect_processes {
                 let publisher = DiscoveryPublisher {
                     process_uuid: process_uuid.clone(),
@@ -668,7 +702,7 @@ impl DiscoveryInner {
                 // A unicast peer contacted me. I need to save its address for
                 // sending future messages in the future.
                 {
-                    let mut relay_addrs = self.relay_addrs.lock().unwrap();
+                    let mut relay_addrs = lock_mutex(&self.relay_addrs, "relay_addrs")?;
                     let addr = SocketAddrV4::new(from_ip, self.multicast_addr.port());
                     relay_addrs.insert(addr);
                 }
@@ -689,7 +723,7 @@ impl DiscoveryInner {
         }
 
         {
-            let mut activity = self.activity.lock().unwrap();
+            let mut activity = lock_mutex(&self.activity, "activity")?;
             activity.insert(msg.process_uuid.clone(), Instant::now());
         }
 
@@ -719,11 +753,12 @@ impl DiscoveryInner {
                 match self
                     .discovery_store
                     .lock()
-                    .unwrap()
+                    .map_err(|err| anyhow::anyhow!("Failed to lock discovery_store: {}", err))?
                     .add_publisher(publisher.clone())
                 {
                     Ok(_) => {
-                        if let Some(cb) = self.connection_cb.lock().unwrap().as_ref() {
+                        if let Some(cb) = lock_mutex(&self.connection_cb, "connection_cb")?.as_ref()
+                        {
                             cb(publisher.clone());
                         }
                     }
@@ -740,7 +775,7 @@ impl DiscoveryInner {
                     // Get registered publishers from the same process.
                     let publishers = {
                         let mut v = vec![];
-                        let store = self.discovery_store.lock().unwrap();
+                        let store = lock_mutex(&self.discovery_store, "discovery_store")?;
                         for p in store.publishers(Some(recv_topic), Some(&msg.process_uuid), None) {
                             if let Ok(scope) = DiscoveryScope::try_from(p.scope) {
                                 if scope == DiscoveryScope::Process
@@ -762,12 +797,13 @@ impl DiscoveryInner {
                 }
             }
             DiscoveryType::NewConnection => {
-                if let Some(cb) = self.registration_cb.lock().unwrap().as_ref() {
+                if let Some(cb) = lock_mutex(&self.registration_cb, "registration_cb")?.as_ref() {
                     cb(publisher.clone());
                 }
             }
             DiscoveryType::EndConnection => {
-                if let Some(cb) = self.unregistration_cb.lock().unwrap().as_ref() {
+                if let Some(cb) = lock_mutex(&self.unregistration_cb, "unregistration_cb")?.as_ref()
+                {
                     cb(publisher.clone());
                 }
             }
@@ -777,19 +813,19 @@ impl DiscoveryInner {
             DiscoveryType::Bye => {
                 // Remove the activity entry for this publisher.
                 {
-                    let mut activity = self.activity.lock().unwrap();
+                    let mut activity = lock_mutex(&self.activity, "activity")?;
                     activity.remove(&msg.process_uuid);
                 }
                 // Notify the new disconnection.
                 publisher.process_uuid = msg.process_uuid.clone();
 
-                if let Some(cb) = self.disconnection_cb.lock().unwrap().as_ref() {
+                if let Some(cb) = lock_mutex(&self.disconnection_cb, "disconnection_cb")?.as_ref() {
                     cb(publisher.clone());
                 }
 
                 // Remove the address entry for this topic.
                 {
-                    let mut store = self.discovery_store.lock().unwrap();
+                    let mut store = lock_mutex(&self.discovery_store, "discovery_store")?;
                     if let Err(e) = store.del_publishers_by_process(&msg.process_uuid) {
                         debug!("Failed to remove publisher: {}", e);
                     }
@@ -803,12 +839,12 @@ impl DiscoveryInner {
                     return Ok(()); // Discard the message.
                 }
 
-                if let Some(cb) = self.disconnection_cb.lock().unwrap().as_ref() {
+                if let Some(cb) = lock_mutex(&self.disconnection_cb, "disconnection_cb")?.as_ref() {
                     cb(publisher.clone());
                 }
 
                 {
-                    let mut store = self.discovery_store.lock().unwrap();
+                    let mut store = lock_mutex(&self.discovery_store, "discovery_store")?;
                     if let Err(e) = store.del_publisher_by_node(
                         &publisher.topic,
                         &publisher.process_uuid,
@@ -892,9 +928,7 @@ impl DiscoveryInner {
 
     async fn send_unicast(&self, msg: &DiscoveryMsg) -> Result<()> {
         let addrs = {
-            self.relay_addrs
-                .lock()
-                .unwrap()
+            lock_mutex(&self.relay_addrs, "relay_addrs")?
                 .iter()
                 .copied()
                 .collect::<Vec<_>>()

--- a/crates/rgz-transport/src/discovery/mod.rs
+++ b/crates/rgz-transport/src/discovery/mod.rs
@@ -64,7 +64,9 @@ fn discovery_msg_encode(msg: &DiscoveryMsg) -> Result<(Vec<u8>, usize)> {
         bail!("Discovery message too large to send. Discovery won't work. This shouldn't happen.");
     }
 
-    let msg_size: u16 = msg_size_full.try_into().unwrap();
+    let msg_size: u16 = msg_size_full
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("Discovery message length overflow: {}", msg_size_full))?;
     let total_size = std::mem::size_of::<u16>() + msg_size as usize;
     let mut buffer = vec![0u8; total_size];
     buffer[0..2].copy_from_slice(&msg_size.to_le_bytes());

--- a/crates/rgz-transport/src/discovery/store.rs
+++ b/crates/rgz-transport/src/discovery/store.rs
@@ -137,37 +137,37 @@ impl DiscoveryStore {
         p_uuid: Option<&str>,
         n_uuid: Option<&str>,
     ) -> Vec<&DiscoveryPublisher> {
-        match (topic.is_some(), p_uuid.is_some(), n_uuid.is_some()) {
-            (true, true, true) => self
-                .publisher(topic.unwrap(), p_uuid.unwrap(), n_uuid.unwrap())
+        match (topic, p_uuid, n_uuid) {
+            (Some(topic), Some(p_uuid), Some(n_uuid)) => self
+                .publisher(topic, p_uuid, n_uuid)
                 .map(|p| vec![p])
-                .unwrap_or(vec![]),
-            (true, true, false) => match self.discovery_publishers.get(topic.unwrap()) {
+                .unwrap_or_default(),
+            (Some(topic), Some(p_uuid), None) => match self.discovery_publishers.get(topic) {
                 Some(process) => process
-                    .get(p_uuid.unwrap())
+                    .get(p_uuid)
                     .map(|p| p.iter().collect())
-                    .unwrap_or(vec![]),
+                    .unwrap_or_default(),
                 None => vec![],
             },
-            (true, false, false) => self.publishers_by_topic(topic.unwrap()),
-            (true, false, true) => match self.discovery_publishers.get(topic.unwrap()) {
+            (Some(topic), None, None) => self.publishers_by_topic(topic),
+            (Some(topic), None, Some(n_uuid)) => match self.discovery_publishers.get(topic) {
                 Some(process) => process
                     .values()
                     .flat_map(|p| p.iter())
-                    .filter(|p| p.node_uuid == n_uuid.unwrap())
+                    .filter(|p| p.node_uuid == n_uuid)
                     .collect(),
                 None => vec![],
             },
-            (false, true, false) => self.publishers_by_process(p_uuid.unwrap()),
-            (false, true, true) => self.publishers_by_node(p_uuid.unwrap(), n_uuid.unwrap()),
-            (false, false, true) => self
+            (None, Some(p_uuid), None) => self.publishers_by_process(p_uuid),
+            (None, Some(p_uuid), Some(n_uuid)) => self.publishers_by_node(p_uuid, n_uuid),
+            (None, None, Some(n_uuid)) => self
                 .discovery_publishers
                 .values()
                 .flat_map(|p| p.values())
                 .flatten()
-                .filter(|p| p.node_uuid == n_uuid.unwrap())
+                .filter(|p| p.node_uuid == n_uuid)
                 .collect(),
-            (false, false, false) => self
+            (None, None, None) => self
                 .discovery_publishers
                 .values()
                 .flat_map(|p| p.values())

--- a/crates/rgz-transport/src/node/node.rs
+++ b/crates/rgz-transport/src/node/node.rs
@@ -84,7 +84,10 @@ impl Node {
         };
 
         let event_sender = {
-            let mut node_shared = self.node_shared.lock().unwrap();
+            let mut node_shared = self
+                .node_shared
+                .lock()
+                .map_err(|err| anyhow::anyhow!("Failed to lock node_shared: {}", err))?;
             node_shared.advertise(discovery_publisher)?
         };
 
@@ -103,7 +106,10 @@ impl Node {
         let fully_qualified_topic = self.create_fully_qualified_topic(topic)?;
         let (msg_sender, mut msg_receiver) = mpsc::unbounded_channel::<PublishMessage>();
         {
-            let mut node_shared = self.node_shared.lock().unwrap();
+            let mut node_shared = self
+                .node_shared
+                .lock()
+                .map_err(|err| anyhow::anyhow!("Failed to lock node_shared: {}", err))?;
             node_shared.subscribe(SubscribeArgs {
                 n_uuid: self.n_uuid.to_string(),
                 topic: fully_qualified_topic.clone(),
@@ -166,7 +172,10 @@ impl Node {
         let (request_sender, mut request_receiver) = mpsc::unbounded_channel::<RequestMessage>();
 
         let event_sender = {
-            let mut node_shared = self.node_shared.lock().unwrap();
+            let mut node_shared = self
+                .node_shared
+                .lock()
+                .map_err(|err| anyhow::anyhow!("Failed to lock node_shared: {}", err))?;
             node_shared.advertise_service(discovery_publisher, request_sender)?
         };
 
@@ -230,7 +239,10 @@ impl Node {
         };
 
         let response_receiver = {
-            let mut node_shared = self.node_shared.lock().unwrap();
+            let mut node_shared = self
+                .node_shared
+                .lock()
+                .map_err(|err| anyhow::anyhow!("Failed to lock node_shared: {}", err))?;
             node_shared.request(RequestMessage {
                 replier_address: None,
                 replier_id: "unset".to_string(),

--- a/crates/rgz-transport/src/node/shared.rs
+++ b/crates/rgz-transport/src/node/shared.rs
@@ -49,7 +49,13 @@ pub(crate) struct NodeShared {
 impl NodeShared {
     pub fn instance() -> Arc<Mutex<NodeShared>> {
         let pid = process::id();
-        let mut node_shared_map = NODE_SHARED_MAP.lock().unwrap();
+        let mut node_shared_map = match NODE_SHARED_MAP.lock() {
+            Ok(map) => map,
+            Err(err) => {
+                error!("NODE_SHARED_MAP lock poisoned: {}", err);
+                err.into_inner()
+            }
+        };
         if let Some(node_shared) = node_shared_map.get(&pid) {
             node_shared.clone()
         } else {
@@ -110,13 +116,19 @@ impl NodeShared {
         }
     }
     fn start(&mut self) {
-        let mut inner = NodeSharedInner::new(
+        let mut inner = match NodeSharedInner::new(
             &self.p_uuid,
             &self.discovery_ip,
             self.msg_disc_port,
             self.srv_disc_port,
             self.verbose,
-        );
+        ) {
+            Ok(inner) => inner,
+            Err(err) => {
+                error!("Failed to initialize NodeSharedInner: {}", err);
+                return;
+            }
+        };
         let node_event_sender = inner.node_event_sender();
         self.node_event_sender = Some(node_event_sender);
 
@@ -180,7 +192,13 @@ impl NodeShared {
 impl Drop for NodeShared {
     fn drop(&mut self) {
         let pid = process::id();
-        let mut node_shared_map = NODE_SHARED_MAP.lock().unwrap();
+        let mut node_shared_map = match NODE_SHARED_MAP.lock() {
+            Ok(map) => map,
+            Err(err) => {
+                error!("NODE_SHARED_MAP lock poisoned on drop: {}", err);
+                err.into_inner()
+            }
+        };
         node_shared_map.remove(&pid);
         if let Some(handle) = self.handle.take() {
             handle.abort();
@@ -217,7 +235,7 @@ impl NodeSharedInner {
         msg_disc_port: u16,
         srv_disc_port: u16,
         verbose: bool,
-    ) -> Self {
+    ) -> Result<Self> {
         let (discovery_event_sender, discovery_event_receiver) =
             mpsc::unbounded_channel::<DiscoveryEvent>();
         let (node_event_sender, node_event_receiver) = mpsc::unbounded_channel::<NodeEvent>();
@@ -229,61 +247,67 @@ impl NodeSharedInner {
 
         let sender = discovery_event_sender.clone();
         msg_discovery.set_connection_cb(move |discovery_publisher| {
-            sender
-                .send(DiscoveryEvent::Connection(discovery_publisher))
-                .unwrap();
+            if let Err(err) = sender.send(DiscoveryEvent::Connection(discovery_publisher)) {
+                error!("Failed to send connection event: {}", err);
+            }
         });
         let sender = discovery_event_sender.clone();
         msg_discovery.set_disconnection_cb(move |discovery_publisher| {
-            sender
-                .send(DiscoveryEvent::Disconnection(discovery_publisher))
-                .unwrap();
+            if let Err(err) = sender.send(DiscoveryEvent::Disconnection(discovery_publisher)) {
+                error!("Failed to send disconnection event: {}", err);
+            }
         });
         let sender = discovery_event_sender.clone();
         msg_discovery.set_registration_cb(move |discovery_publisher| {
-            sender
-                .send(DiscoveryEvent::Registration(discovery_publisher))
-                .unwrap();
+            if let Err(err) = sender.send(DiscoveryEvent::Registration(discovery_publisher)) {
+                error!("Failed to send registration event: {}", err);
+            }
         });
         let sender = discovery_event_sender.clone();
         msg_discovery.set_unregistration_cb(move |discovery_publisher| {
-            sender
-                .send(DiscoveryEvent::Unregistration(discovery_publisher))
-                .unwrap();
+            if let Err(err) = sender.send(DiscoveryEvent::Unregistration(discovery_publisher)) {
+                error!("Failed to send unregistration event: {}", err);
+            }
         });
 
         // srv discovery
         let mut srv_discovery = Discovery::new(p_uuid, discovery_ip, srv_disc_port, verbose);
         let sender = discovery_event_sender.clone();
         srv_discovery.set_connection_cb(move |discovery_publisher| {
-            sender
-                .send(DiscoveryEvent::SrvConnection(discovery_publisher))
-                .unwrap();
+            if let Err(err) = sender.send(DiscoveryEvent::SrvConnection(discovery_publisher)) {
+                error!("Failed to send service connection event: {}", err);
+            }
         });
         let sender = discovery_event_sender.clone();
         srv_discovery.set_disconnection_cb(move |discovery_publisher| {
-            sender
-                .send(DiscoveryEvent::SrvDisconnection(discovery_publisher))
-                .unwrap();
+            if let Err(err) = sender.send(DiscoveryEvent::SrvDisconnection(discovery_publisher)) {
+                error!("Failed to send service disconnection event: {}", err);
+            }
         });
 
         // transporter
         let host_addr = msg_discovery.host_addr().to_string();
-        let mut transporter = Transporter::new(&host_addr);
+        let mut transporter = Transporter::new(&host_addr)?;
         let sender = transport_event_sender.clone();
         transporter.set_subscription_handler(move |msg| {
-            sender.send(TransportEvent::Subscription(msg)).unwrap();
+            if let Err(err) = sender.send(TransportEvent::Subscription(msg)) {
+                error!("Failed to forward subscription event: {}", err);
+            }
         });
         let sender = transport_event_sender.clone();
         transporter.set_request_handler(move |msg| {
-            sender.send(TransportEvent::Request(msg)).unwrap();
+            if let Err(err) = sender.send(TransportEvent::Request(msg)) {
+                error!("Failed to forward request event: {}", err);
+            }
         });
         let sender = transport_event_sender.clone();
         transporter.set_response_handler(move |msg| {
-            sender.send(TransportEvent::Response(msg)).unwrap();
+            if let Err(err) = sender.send(TransportEvent::Response(msg)) {
+                error!("Failed to forward response event: {}", err);
+            }
         });
 
-        NodeSharedInner {
+        Ok(NodeSharedInner {
             p_uuid: p_uuid.to_string(),
             discovery_event_receiver,
             discovery_event_sender,
@@ -298,7 +322,7 @@ impl NodeSharedInner {
             response_dispatchers: DispatcherStore::new(),
             services: DispatcherStore::new(),
             verbose,
-        }
+        })
     }
 
     fn node_event_sender(&self) -> UnboundedSender<NodeEvent> {
@@ -483,7 +507,12 @@ impl NodeSharedInner {
         }
 
         // Delete a remote subscriber.
-        self.subscribers.remove_by_node(topic, node_uuid).unwrap();
+        if self.subscribers.remove_by_node(topic, node_uuid).is_none() {
+            error!(
+                "Failed to remove subscriber [{}/{}]: no matching subscriber",
+                topic, node_uuid
+            );
+        }
     }
 
     fn on_srv_connection(&mut self, discovery_publisher: DiscoveryPublisher) {
@@ -566,7 +595,9 @@ impl NodeSharedInner {
             info!("Failed to register dispatcher: {}", err);
         }
         // Advertise the service.
-        self.srv_discovery.advertise(discovery_publisher).unwrap();
+        if let Err(err) = self.srv_discovery.advertise(discovery_publisher) {
+            error!("Failed to advertise service: {}", err);
+        }
     }
     fn on_subscribe(&mut self, args: SubscribeArgs) {
         trace!("on_subscribe");
@@ -599,9 +630,9 @@ impl NodeSharedInner {
                     }
                 } else {
                     // Send the message to the local subscriber.
-                    dispatcher
-                        .dispatch(publish_message)
-                        .expect("Failed to dispatch message");
+                    if let Err(err) = dispatcher.dispatch(publish_message) {
+                        error!("Failed to dispatch local publish message: {}", err);
+                    }
                 }
             }
         }
@@ -625,7 +656,9 @@ impl NodeSharedInner {
             if let Err(err) = self.response_dispatchers.register(dispatcher) {
                 error!("Failed to register dispatcher: {}", err);
             }
-            service.request(request_message).expect("Failed to request");
+            if let Err(err) = service.request(request_message) {
+                error!("Failed to request local service: {}", err);
+            }
             return;
         }
 
@@ -699,10 +732,10 @@ impl NodeSharedInner {
             .filter(&msg.topic, Some(&msg.msg_type), None)
         {
             for subscriber in subscribers {
-                if !subscriber.is_remote() {
-                    subscriber
-                        .dispatch(msg.clone())
-                        .expect("Failed to dispatch message");
+                if !subscriber.is_remote()
+                    && let Err(err) = subscriber.dispatch(msg.clone())
+                {
+                    error!("Failed to dispatch local subscription message: {}", err);
                 }
             }
         }
@@ -719,7 +752,9 @@ impl NodeSharedInner {
             if let Err(err) = self.response_dispatchers.register(dispatcher) {
                 error!("Failed to register dispatcher: {}", err);
             }
-            service.request(request_message).expect("Failed to request");
+            if let Err(err) = service.request(request_message) {
+                error!("Failed to request service: {}", err);
+            }
         } else {
             error!("Service not found");
         }
@@ -733,9 +768,9 @@ impl NodeSharedInner {
             self.response_dispatchers
                 .get(&msg.topic, &msg.node_uuid, &msg.req_uuid)
         {
-            dispatcher
-                .dispatch(msg)
-                .expect("Failed to dispatch message");
+            if let Err(err) = dispatcher.dispatch(msg) {
+                error!("Failed to dispatch response message: {}", err);
+            }
             dispatcher.done();
         } else {
             error!("ResponseDispatcher not found");

--- a/crates/rgz-transport/src/transport.rs
+++ b/crates/rgz-transport/src/transport.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::thread::sleep;
 use std::time::Duration;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use tracing::{debug, error};
 
 /// Timeout used for receiving messages (ms.).
@@ -86,28 +86,28 @@ pub(crate) struct Transporter {
 }
 
 impl Transporter {
-    pub(crate) fn new(host_addr: &str) -> Self {
+    pub(crate) fn new(host_addr: &str) -> Result<Self> {
         let any_tcp = format!("tcp://{}:*", host_addr);
         let context = zmq::Context::new();
-        let publisher = context.socket(zmq::PUB).unwrap();
+        let publisher = context.socket(zmq::PUB)?;
         let linger_val = 0;
-        publisher.set_linger(linger_val).unwrap();
-        publisher.set_sndhwm(DEFAULT_SND_HWM).unwrap();
-        publisher.bind(&any_tcp).expect("failed binding publisher");
+        publisher.set_linger(linger_val)?;
+        publisher.set_sndhwm(DEFAULT_SND_HWM)?;
+        publisher.bind(&any_tcp)?;
 
         let publisher_address = match publisher.get_last_endpoint() {
             Ok(Ok(endpoint)) => endpoint,
             _ => "".to_string(),
         };
-        let requester = context.socket(zmq::ROUTER).unwrap();
-        requester.set_linger(linger_val).unwrap();
-        requester.set_router_mandatory(true).unwrap();
+        let requester = context.socket(zmq::ROUTER)?;
+        requester.set_linger(linger_val)?;
+        requester.set_router_mandatory(true)?;
         let requester_id = uuid::Uuid::new_v4().to_string();
         let requester_address = Arc::new(Mutex::new("unset".to_string()));
         let replier_id = uuid::Uuid::new_v4().to_string();
         let replier_address = Arc::new(Mutex::new("unset".to_string()));
 
-        Transporter {
+        Ok(Transporter {
             host_addr: host_addr.to_string(),
             context,
             publisher,
@@ -124,7 +124,7 @@ impl Transporter {
             response_handler: Arc::new(Mutex::new(None)),
             subscribe_evt_sender: None,
             reply_msg_sender: None,
-        }
+        })
     }
 
     pub(crate) fn publisher_address(&self) -> String {
@@ -132,7 +132,13 @@ impl Transporter {
     }
 
     pub(crate) fn replier_address(&self) -> String {
-        self.replier_address.lock().unwrap().clone()
+        match self.replier_address.lock() {
+            Ok(address) => address.clone(),
+            Err(err) => {
+                error!("Failed to lock replier_address: {}", err);
+                String::new()
+            }
+        }
     }
     pub(crate) fn replier_id(&self) -> String {
         self.replier_id.clone()
@@ -146,25 +152,37 @@ impl Transporter {
         unsubscribe_topic: Option<&str>,
     ) {
         if let Some(event_sender) = self.subscribe_evt_sender.as_ref() {
-            event_sender
-                .send(SubscribeEvent {
-                    connect: connect.map(|s| s.to_string()),
-                    disconnect: disconnect.map(|s| s.to_string()),
-                    subscribe: subscribe_topic.map(|s| s.to_string()),
-                    unsubscribe: unsubscribe_topic.map(|s| s.to_string()),
-                })
-                .expect("subscribe failed");
+            if let Err(err) = event_sender.send(SubscribeEvent {
+                connect: connect.map(|s| s.to_string()),
+                disconnect: disconnect.map(|s| s.to_string()),
+                subscribe: subscribe_topic.map(|s| s.to_string()),
+                unsubscribe: unsubscribe_topic.map(|s| s.to_string()),
+            }) {
+                error!("Failed to enqueue subscribe event: {}", err);
+            }
         } else {
             error!("There is no sender. Transporter may not have started.");
         }
     }
 
     pub(crate) fn connections(&self) -> Vec<String> {
-        let connections = self.connections.lock().unwrap();
-        connections.iter().cloned().collect()
+        match self.connections.lock() {
+            Ok(connections) => connections.iter().cloned().collect(),
+            Err(err) => {
+                error!("Failed to lock connections: {}", err);
+                Vec::new()
+            }
+        }
     }
     pub(crate) fn srv_disconnect(&self, address: &str) {
-        self.srv_connections.lock().unwrap().remove(address);
+        if let Ok(mut srv_connections) = self.srv_connections.lock() {
+            srv_connections.remove(address);
+        } else {
+            error!(
+                "Failed to lock srv_connections while disconnecting [{}]",
+                address
+            );
+        }
     }
 
     pub(crate) fn publish(&self, publish_message: PublishMessage) -> Result<()> {
@@ -192,7 +210,10 @@ impl Transporter {
         };
 
         {
-            let mut srv_connections = self.srv_connections.lock().unwrap();
+            let mut srv_connections = self
+                .srv_connections
+                .lock()
+                .map_err(|err| anyhow::anyhow!("Failed to lock srv_connections: {}", err))?;
             if srv_connections.insert(address.clone()) {
                 self.requester.connect(&address)?;
                 debug!("Connected to [{}] for service requests", address);
@@ -200,7 +221,11 @@ impl Transporter {
             }
         }
 
-        let my_requester_address = self.requester_address.lock().unwrap().clone();
+        let my_requester_address = self
+            .requester_address
+            .lock()
+            .map_err(|err| anyhow::anyhow!("Failed to lock requester_address: {}", err))?
+            .clone();
         let messages = [
             zmq::Message::from(&msg.replier_id),
             zmq::Message::from(&msg.topic),
@@ -235,30 +260,36 @@ impl Transporter {
     where
         F: Fn(PublishMessage) + Send + 'static,
     {
-        self.subscription_handler
-            .lock()
-            .unwrap()
-            .replace(Box::new(handler));
+        match self.subscription_handler.lock() {
+            Ok(mut h) => {
+                h.replace(Box::new(handler));
+            }
+            Err(err) => error!("Failed to lock subscription_handler: {}", err),
+        }
     }
 
     pub(crate) fn set_request_handler<F>(&mut self, handler: F)
     where
         F: Fn(RequestMessage) + Send + 'static,
     {
-        self.request_handler
-            .lock()
-            .unwrap()
-            .replace(Box::new(handler));
+        match self.request_handler.lock() {
+            Ok(mut h) => {
+                h.replace(Box::new(handler));
+            }
+            Err(err) => error!("Failed to lock request_handler: {}", err),
+        }
     }
 
     pub(crate) fn set_response_handler<F>(&mut self, handler: F)
     where
         F: Fn(ReplyMessage) + Send + 'static,
     {
-        self.response_handler
-            .lock()
-            .unwrap()
-            .replace(Box::new(handler));
+        match self.response_handler.lock() {
+            Ok(mut h) => {
+                h.replace(Box::new(handler));
+            }
+            Err(err) => error!("Failed to lock response_handler: {}", err),
+        }
     }
 
     pub(crate) fn start(&mut self) {
@@ -280,7 +311,7 @@ impl Transporter {
         let response_handler = self.response_handler.clone();
 
         thread::spawn(move || {
-            let mut inner = TransporterInner::new(
+            let mut inner = match TransporterInner::new(
                 context,
                 &host_addr,
                 &requester_id,
@@ -292,7 +323,13 @@ impl Transporter {
                 subscription_handler,
                 request_handler,
                 response_handler,
-            );
+            ) {
+                Ok(inner) => inner,
+                Err(err) => {
+                    error!("Failed to initialize transport thread: {}", err);
+                    return;
+                }
+            };
 
             loop {
                 if let Ok(event) = subscribe_evt_receiver.try_recv() {
@@ -324,7 +361,9 @@ impl Transporter {
                     error!("failed replying: {}", e);
                 }
 
-                inner.poll(TIMEOUT).expect("poll failed");
+                if let Err(err) = inner.poll(TIMEOUT) {
+                    error!("Transport poll failed: {}", err);
+                }
             }
         });
     }
@@ -362,42 +401,46 @@ impl TransporterInner {
         subscription_handler: Arc<Mutex<Option<SubscriptionHandlerType>>>,
         request_handler: Arc<Mutex<Option<RequestHandlerType>>>,
         response_handler: Arc<Mutex<Option<ResponseHandlerType>>>,
-    ) -> Self {
+    ) -> Result<Self> {
         let any_tcp = format!("tcp://{}:*", host_addr);
         let requester_id = requester_id.to_string();
         let replier_id = replier_id.to_string();
 
-        let subscriber = context.socket(zmq::SUB).unwrap();
-        let response_receiver = context.socket(zmq::ROUTER).unwrap();
-        let replier = context.socket(zmq::ROUTER).unwrap();
+        let subscriber = context.socket(zmq::SUB)?;
+        let response_receiver = context.socket(zmq::ROUTER)?;
+        let replier = context.socket(zmq::ROUTER)?;
 
-        subscriber.set_rcvhwm(DEFAULT_RCV_HWM).unwrap();
+        subscriber.set_rcvhwm(DEFAULT_RCV_HWM)?;
 
         response_receiver
             .set_identity(requester_id.as_bytes())
-            .unwrap();
-        response_receiver
-            .bind(&any_tcp)
-            .expect("failed binding response_receiver");
+            .context("Failed setting response receiver identity")?;
+        response_receiver.bind(&any_tcp)?;
         let address = match response_receiver.get_last_endpoint() {
             Ok(Ok(endpoint)) => endpoint,
             _ => "error".to_string(),
         };
-        *requester_address.lock().unwrap() = address.clone();
+        *requester_address
+            .lock()
+            .map_err(|err| anyhow::anyhow!("Failed to lock requester_address: {}", err))? =
+            address.clone();
 
-        replier.set_identity(replier_id.as_bytes()).unwrap();
+        replier.set_identity(replier_id.as_bytes())?;
         let linger_val = 0;
-        replier.set_linger(linger_val).unwrap();
+        replier.set_linger(linger_val)?;
         let route_on = true;
-        replier.set_router_mandatory(route_on).unwrap();
-        replier.bind(&any_tcp).expect("failed binding replier");
+        replier.set_router_mandatory(route_on)?;
+        replier.bind(&any_tcp)?;
         let address = match replier.get_last_endpoint() {
             Ok(Ok(endpoint)) => endpoint,
             _ => "".to_string(),
         };
-        *replier_address.lock().unwrap() = address.clone();
+        *replier_address
+            .lock()
+            .map_err(|err| anyhow::anyhow!("Failed to lock replier_address: {}", err))? =
+            address.clone();
 
-        TransporterInner {
+        Ok(TransporterInner {
             subscriber,
             response_receiver,
             replier,
@@ -410,11 +453,14 @@ impl TransporterInner {
             subscription_handler,
             request_handler,
             response_handler,
-        }
+        })
     }
 
     fn connect(&self, address: &str) -> Result<()> {
-        let mut connections = self.connections.lock().unwrap();
+        let mut connections = self
+            .connections
+            .lock()
+            .map_err(|err| anyhow::anyhow!("Failed to lock connections: {}", err))?;
         if connections.insert(address.to_string()) {
             self.subscriber.connect(address)?;
             debug!("Connected to [{}] for subscriptions", address);
@@ -424,7 +470,10 @@ impl TransporterInner {
         Ok(())
     }
     fn disconnect(&self, address: &str) -> Result<()> {
-        self.connections.lock().unwrap().remove(address);
+        self.connections
+            .lock()
+            .map_err(|err| anyhow::anyhow!("Failed to lock connections: {}", err))?
+            .remove(address);
         self.subscriber.disconnect(address)?;
         Ok(())
     }
@@ -446,7 +495,10 @@ impl TransporterInner {
         };
 
         {
-            let mut srv_connections = self.srv_connections.lock().unwrap();
+            let mut srv_connections = self
+                .srv_connections
+                .lock()
+                .map_err(|err| anyhow::anyhow!("Failed to lock srv_connections: {}", err))?;
             if srv_connections.insert(address.clone()) {
                 self.replier.connect(&address)?;
                 debug!("Connected to [{}] for service response", address);
@@ -500,7 +552,12 @@ impl TransporterInner {
         let data = self.subscriber.recv_msg(0)?;
         let msg_type = self.subscriber.recv_msg(0)?;
 
-        if let Some(handler) = self.subscription_handler.lock().unwrap().as_ref() {
+        if let Some(handler) = self
+            .subscription_handler
+            .lock()
+            .map_err(|err| anyhow::anyhow!("Failed to lock subscription_handler: {}", err))?
+            .as_ref()
+        {
             handler(PublishMessage {
                 topic: topic.as_str().unwrap_or("").to_string(),
                 data: data.to_vec(),
@@ -522,7 +579,12 @@ impl TransporterInner {
         let req_type = self.replier.recv_msg(0)?;
         let res_type = self.replier.recv_msg(0)?;
 
-        if let Some(handler) = self.request_handler.lock().unwrap().as_ref() {
+        if let Some(handler) = self
+            .request_handler
+            .lock()
+            .map_err(|err| anyhow::anyhow!("Failed to lock request_handler: {}", err))?
+            .as_ref()
+        {
             handler(RequestMessage {
                 replier_address: None,
                 replier_id: replier_id.as_str().unwrap_or("").to_string(),
@@ -541,13 +603,18 @@ impl TransporterInner {
 
     fn on_response(&self) -> Result<()> {
         let requester_id = self.response_receiver.recv_msg(0)?;
-        let topic = self.response_receiver.recv_msg(0).unwrap();
-        let node_uuid = self.response_receiver.recv_msg(0).unwrap();
-        let req_uuid = self.response_receiver.recv_msg(0).unwrap();
-        let data = self.response_receiver.recv_msg(0).unwrap();
-        let result_str = self.response_receiver.recv_msg(0).unwrap();
+        let topic = self.response_receiver.recv_msg(0)?;
+        let node_uuid = self.response_receiver.recv_msg(0)?;
+        let req_uuid = self.response_receiver.recv_msg(0)?;
+        let data = self.response_receiver.recv_msg(0)?;
+        let result_str = self.response_receiver.recv_msg(0)?;
 
-        if let Some(handler) = self.response_handler.lock().unwrap().as_ref() {
+        if let Some(handler) = self
+            .response_handler
+            .lock()
+            .map_err(|err| anyhow::anyhow!("Failed to lock response_handler: {}", err))?
+            .as_ref()
+        {
             handler(ReplyMessage {
                 requester_address: None,
                 requester_id: requester_id.as_str().unwrap_or("").to_string(),


### PR DESCRIPTION
## Summary
This PR addresses Issue #4 by replacing `unwrap/expect` in runtime paths within `discovery/transport/node` with structured error handling (`Result` propagation or guarded handling).  
The goal is to avoid panic-based control flow for recoverable failures and improve operational error context.

## What Changed
- Removed `unwrap/expect` from runtime paths (test-only usage under `#[cfg(test)]` is intentionally left as-is).
- Changed `Transporter::new` to return `Result<Self>` and propagated initialization failures.
- Changed `NodeSharedInner::new` to return `Result<Self>` and added startup failure logging.
- Replaced panic-prone lock/send operations with guarded handling and contextual error logs.
- Removed panic paths in discovery parse/conversion/callback flows.
- Refactored `DiscoveryStore::publishers` to avoid `Option::unwrap`-based branching.

## Files Updated
- `crates/rgz-transport/src/discovery/discovery.rs`
- `crates/rgz-transport/src/discovery/mod.rs`
- `crates/rgz-transport/src/discovery/store.rs`
- `crates/rgz-transport/src/node/node.rs`
- `crates/rgz-transport/src/node/shared.rs`
- `crates/rgz-transport/src/transport.rs`

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p rgz-transport --lib` (22 passed)

## Behavioral Impact
- Normal behavior remains functionally equivalent.
- Failure behavior changes from panic to structured error handling with actionable logs.

Closes #4