### PR TITLE
Implement transport reconnect lifecycle

### DIFF
--- a/crates/rgz-transport/src/actor.rs
+++ b/crates/rgz-transport/src/actor.rs
@@ -93,6 +93,10 @@ impl ActorZmqConfig {
 }
 
 struct ActorZmqRuntime {
+    // The actor owns this mutable snapshot. Connect/disconnect rebuilds sockets from it so
+    // socket halves and receive tasks never outlive the endpoint configuration that created them.
+    config: ActorZmqConfig,
+    subscriptions: HashSet<String>,
     publisher: Option<PubSocket>,
     sub_cmd_tx: Option<mpsc::Sender<SubControlCommand>>,
     request_send: Option<DealerSendHalf>,
@@ -109,6 +113,8 @@ impl ActorZmqRuntime {
         if !config.enabled {
             let (_, io_event_rx) = mpsc::channel(1);
             return Ok(Self {
+                config: config.clone(),
+                subscriptions: HashSet::new(),
                 publisher: None,
                 sub_cmd_tx: None,
                 request_send: None,
@@ -263,6 +269,8 @@ impl ActorZmqRuntime {
         }
 
         Ok(Self {
+            config: config.clone(),
+            subscriptions: HashSet::new(),
             publisher,
             sub_cmd_tx,
             request_send,
@@ -282,7 +290,56 @@ impl ActorZmqRuntime {
         if let Some(handle) = self.req_task.take() {
             handle.abort();
         }
+        self.publisher = None;
+        self.request_send = None;
     }
+
+    fn connect_endpoint(&mut self, endpoint: &str) {
+        add_endpoint(&mut self.config.pub_connect, endpoint);
+        add_endpoint(&mut self.config.sub_connect, endpoint);
+        add_endpoint(&mut self.config.req_connect, endpoint);
+    }
+
+    fn disconnect_endpoint(&mut self, endpoint: &str) {
+        remove_endpoint(&mut self.config.pub_connect, endpoint);
+        remove_endpoint(&mut self.config.sub_connect, endpoint);
+        remove_endpoint(&mut self.config.req_connect, endpoint);
+    }
+
+    fn is_active(&self) -> bool {
+        self.request_send.is_some() || self.sub_cmd_tx.is_some() || self.publisher.is_some()
+    }
+
+    /// Recreate all live sockets after an endpoint change, then restore subscriptions before
+    /// normal traffic resumes. Rebuilding as one unit keeps PUB/SUB/DEALER lifecycle aligned.
+    async fn rebuild(&mut self, metrics: Arc<TransportMetrics>) -> Result<(), String> {
+        let config = self.config.clone();
+        let subscriptions = self.subscriptions.clone();
+        self.stop().await;
+        let mut replacement = Self::initialize(&config, metrics).await?;
+
+        if let Some(sub_cmd_tx) = replacement.sub_cmd_tx.as_ref() {
+            for topic in subscriptions {
+                sub_cmd_tx
+                    .send(SubControlCommand::Subscribe(topic))
+                    .await
+                    .map_err(|err| format!("failed to restore subscription: {err}"))?;
+            }
+        }
+        replacement.subscriptions = self.subscriptions.clone();
+        *self = replacement;
+        Ok(())
+    }
+}
+
+fn add_endpoint(endpoints: &mut Vec<String>, endpoint: &str) {
+    if !endpoints.iter().any(|candidate| candidate == endpoint) {
+        endpoints.push(endpoint.to_string());
+    }
+}
+
+fn remove_endpoint(endpoints: &mut Vec<String>, endpoint: &str) {
+    endpoints.retain(|candidate| candidate != endpoint);
 }
 
 fn try_emit_io_event(
@@ -692,7 +749,7 @@ pub enum TxCmd {
         topic: String,
     },
 
-    /// Connect to an adapter endpoint.
+    /// Connect to an adapter endpoint by rebuilding the affected ZeroMQ runtime.
     Connect {
         /// Endpoint string for the adapter.
         endpoint: String,
@@ -700,7 +757,7 @@ pub enum TxCmd {
         namespace: Option<String>,
     },
 
-    /// Disconnect from a connected endpoint.
+    /// Disconnect from an endpoint by stopping and rebuilding the affected ZeroMQ runtime.
     Disconnect {
         /// Endpoint string to disconnect from.
         endpoint: String,
@@ -949,14 +1006,10 @@ impl TransportActor {
         let inbound_requests: Arc<Mutex<HashSet<RequestId>>> = Arc::new(Mutex::new(HashSet::new()));
         let mut command_open = true;
         let mut control_open = true;
-        let io_runtime_active = io_runtime.request_send.is_some()
-            || io_runtime.sub_cmd_tx.is_some()
-            || io_runtime.publisher.is_some();
-
         while command_open || control_open {
             tokio::select! {
                 biased;
-                io_event = io_runtime.io_event_rx.recv(), if io_runtime_active => {
+                io_event = io_runtime.io_event_rx.recv(), if io_runtime.is_active() => {
                     match io_event {
                         Some(InternalIoEvent::IncomingPublish { topic, payload }) => {
                             try_emit_event(
@@ -1346,10 +1399,12 @@ impl TransportActor {
                                     )
                                     .await;
                                 } else {
+                                    io_runtime.subscriptions.insert(topic.clone());
                                     emit_transport_recovery(&state).await;
                                     try_emit_event(&event_tx, metrics.as_ref(), RxEvent::Subscribed { topic });
                                 }
                             } else {
+                                io_runtime.subscriptions.insert(topic.clone());
                                 try_emit_event(&event_tx, metrics.as_ref(), RxEvent::Subscribed { topic });
                             }
                         }
@@ -1372,18 +1427,50 @@ impl TransportActor {
                                     )
                                     .await;
                                 } else {
+                                    io_runtime.subscriptions.remove(&topic);
                                     emit_transport_recovery(&state).await;
                                     try_emit_event(&event_tx, metrics.as_ref(), RxEvent::Unsubscribed { topic });
                                 }
                             } else {
+                                io_runtime.subscriptions.remove(&topic);
                                 try_emit_event(&event_tx, metrics.as_ref(), RxEvent::Unsubscribed { topic });
                             }
                         }
                         Some(TxCmd::Connect { endpoint, namespace: _ }) => {
-                            try_emit_event(&event_tx, metrics.as_ref(), RxEvent::Connected { endpoint });
-                            emit_transport_recovery(&state).await;
+                            io_runtime.connect_endpoint(&endpoint);
+                            match io_runtime.rebuild(Arc::clone(&metrics)).await {
+                                Ok(()) => {
+                                    try_emit_event(&event_tx, metrics.as_ref(), RxEvent::Connected { endpoint });
+                                    emit_transport_recovery(&state).await;
+                                }
+                                Err(err) => {
+                                    emit_state_error(
+                                        &state,
+                                        &event_tx,
+                                        metrics.as_ref(),
+                                        None,
+                                        TransportError::TemporaryTransport(format!(
+                                            "reconnect failed: {err}"
+                                        )),
+                                    )
+                                    .await;
+                                }
+                            }
                         }
                         Some(TxCmd::Disconnect { endpoint, reason }) => {
+                            io_runtime.disconnect_endpoint(&endpoint);
+                            if let Err(err) = io_runtime.rebuild(Arc::clone(&metrics)).await {
+                                emit_state_error(
+                                    &state,
+                                    &event_tx,
+                                    metrics.as_ref(),
+                                    None,
+                                    TransportError::TemporaryTransport(format!(
+                                        "disconnect failed: {err}"
+                                    )),
+                                )
+                                .await;
+                            }
                             try_emit_event(
                                 &event_tx,
                                 metrics.as_ref(),
@@ -2423,6 +2510,252 @@ mod tests {
             timeout(Duration::from_secs(2), ack_rx2).await,
             Ok(Ok(Ok(())))
         ));
+    }
+
+    #[cfg(feature = "network-tests")]
+    #[tokio::test]
+    #[ignore = "requires zeromq bind/connect permissions"]
+    async fn zeromq_pub_sub_disconnect_then_reconnect_recovers_delivery() {
+        let endpoint = next_tcp_endpoint();
+        let pub_config = TransportConfig {
+            enable_zeromq_io: true,
+            zeromq_pub_bind: Some(endpoint.clone()),
+            ..TransportConfig::default()
+        };
+        let sub_config = TransportConfig {
+            enable_zeromq_io: true,
+            zeromq_sub_connect: vec![endpoint.clone()],
+            ..TransportConfig::default()
+        };
+
+        let (publisher, publisher_state) = spawn_with_config(pub_config).await;
+        sleep(Duration::from_millis(200)).await;
+        let (mut subscriber, subscriber_state) = spawn_with_config(sub_config).await;
+        sleep(Duration::from_millis(200)).await;
+        if *publisher_state.lock().await == TransportState::Failed
+            || *subscriber_state.lock().await == TransportState::Failed
+        {
+            eprintln!("skipping: zeromq bind/connect not permitted in this environment");
+            return;
+        }
+
+        let topic = "telemetry/reconnect".to_string();
+        subscriber
+            .command_tx
+            .send(TxCmd::Subscribe {
+                topic: topic.clone(),
+            })
+            .await
+            .expect("subscribe command");
+        let _ = recv_until(&mut subscriber.event_rx, Duration::from_secs(1), |event| {
+            matches!(event, RxEvent::Subscribed { topic: event_topic } if event_topic == &topic)
+        })
+        .await;
+
+        subscriber
+            .command_tx
+            .send(TxCmd::Disconnect {
+                endpoint: endpoint.clone(),
+                reason: Some("test reconnect".to_string()),
+            })
+            .await
+            .expect("disconnect command");
+        assert!(matches!(
+            recv_until(&mut subscriber.event_rx, Duration::from_secs(2), |event| {
+                matches!(event, RxEvent::Disconnected { endpoint: event_endpoint, .. } if event_endpoint == &endpoint)
+            })
+            .await,
+            Some(RxEvent::Disconnected { .. })
+        ));
+
+        subscriber
+            .command_tx
+            .send(TxCmd::Connect {
+                endpoint: endpoint.clone(),
+                namespace: None,
+            })
+            .await
+            .expect("connect command");
+        assert!(matches!(
+            recv_until(&mut subscriber.event_rx, Duration::from_secs(2), |event| {
+                matches!(event, RxEvent::Connected { endpoint: event_endpoint } if event_endpoint == &endpoint)
+            })
+            .await,
+            Some(RxEvent::Connected { .. })
+        ));
+
+        sleep(Duration::from_millis(200)).await;
+        let mut delivered = false;
+        for _ in 0..20 {
+            publisher
+                .command_tx
+                .send(TxCmd::Publish {
+                    topic: topic.clone(),
+                    payload: b"recovered".to_vec(),
+                    headers: None,
+                })
+                .await
+                .expect("publish command");
+            if matches!(
+                recv_until(&mut subscriber.event_rx, Duration::from_millis(150), |event| {
+                    matches!(
+                        event,
+                        RxEvent::IncomingPublish { topic: event_topic, payload, .. }
+                            if event_topic == &topic && payload == b"recovered"
+                    )
+                })
+                .await,
+                Some(RxEvent::IncomingPublish { .. })
+            ) {
+                delivered = true;
+                break;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+        assert!(delivered, "message was not delivered after reconnect");
+
+        for channels in [&publisher, &subscriber] {
+            let (ack_tx, ack_rx) = oneshot::channel();
+            channels
+                .control_tx
+                .send(TxCmd::Shutdown {
+                    graceful: false,
+                    timeout_ms: None,
+                    ack: ack_tx,
+                })
+                .await
+                .expect("shutdown command");
+            assert!(matches!(
+                timeout(Duration::from_secs(2), ack_rx).await,
+                Ok(Ok(Ok(())))
+            ));
+        }
+    }
+
+    #[cfg(feature = "network-tests")]
+    #[tokio::test]
+    #[ignore = "requires zeromq bind/connect permissions"]
+    async fn zeromq_request_reply_disconnect_then_reconnect_recovers_delivery() {
+        let endpoint = next_tcp_endpoint();
+        let server_config = TransportConfig {
+            enable_zeromq_io: true,
+            zeromq_req_bind: Some(endpoint.clone()),
+            ..TransportConfig::default()
+        };
+        let client_config = TransportConfig {
+            enable_zeromq_io: true,
+            zeromq_req_connect: vec![endpoint.clone()],
+            ..TransportConfig::default()
+        };
+
+        let (mut server, server_state) = spawn_with_config(server_config).await;
+        sleep(Duration::from_millis(200)).await;
+        let (mut client, client_state) = spawn_with_config(client_config).await;
+        sleep(Duration::from_millis(200)).await;
+        if *server_state.lock().await == TransportState::Failed
+            || *client_state.lock().await == TransportState::Failed
+        {
+            eprintln!("skipping: zeromq bind/connect not permitted in this environment");
+            return;
+        }
+
+        client
+            .command_tx
+            .send(TxCmd::Disconnect {
+                endpoint: endpoint.clone(),
+                reason: Some("test reconnect".to_string()),
+            })
+            .await
+            .expect("disconnect command");
+        assert!(matches!(
+            recv_until(&mut client.event_rx, Duration::from_secs(2), |event| {
+                matches!(event, RxEvent::Disconnected { endpoint: event_endpoint, .. } if event_endpoint == &endpoint)
+            })
+            .await,
+            Some(RxEvent::Disconnected { .. })
+        ));
+
+        client
+            .command_tx
+            .send(TxCmd::Connect {
+                endpoint: endpoint.clone(),
+                namespace: None,
+            })
+            .await
+            .expect("connect command");
+        assert!(matches!(
+            recv_until(&mut client.event_rx, Duration::from_secs(2), |event| {
+                matches!(event, RxEvent::Connected { endpoint: event_endpoint } if event_endpoint == &endpoint)
+            })
+            .await,
+            Some(RxEvent::Connected { .. })
+        ));
+
+        let request_id = 9002u64;
+        client
+            .command_tx
+            .send(TxCmd::SendRequest {
+                request: TxRequest {
+                    request_id,
+                    topic: "svc/reconnect".to_string(),
+                    payload: b"ping".to_vec(),
+                    headers: None,
+                    timeout_ms: Some(1_000),
+                },
+            })
+            .await
+            .expect("request command");
+        assert!(matches!(
+            recv_until(&mut server.event_rx, Duration::from_secs(2), |event| {
+                matches!(
+                    event,
+                    RxEvent::IncomingRequest { request_id: event_id, .. } if *event_id == request_id
+                )
+            })
+            .await,
+            Some(RxEvent::IncomingRequest { .. })
+        ));
+
+        server
+            .command_tx
+            .send(TxCmd::SendReply {
+                reply: TxReply {
+                    request_id,
+                    payload: b"pong".to_vec(),
+                    status: ReplyStatus::Ok,
+                    headers: None,
+                },
+            })
+            .await
+            .expect("reply command");
+        assert!(matches!(
+            recv_until(&mut client.event_rx, Duration::from_secs(2), |event| {
+                matches!(
+                    event,
+                    RxEvent::IncomingReply { request_id: event_id, payload, status, .. }
+                        if *event_id == request_id && payload == b"pong" && *status == ReplyStatus::Ok
+                )
+            })
+            .await,
+            Some(RxEvent::IncomingReply { .. })
+        ));
+
+        for channels in [&server, &client] {
+            let (ack_tx, ack_rx) = oneshot::channel();
+            channels
+                .control_tx
+                .send(TxCmd::Shutdown {
+                    graceful: false,
+                    timeout_ms: None,
+                    ack: ack_tx,
+                })
+                .await
+                .expect("shutdown command");
+            assert!(matches!(
+                timeout(Duration::from_secs(2), ack_rx).await,
+                Ok(Ok(Ok(())))
+            ));
+        }
     }
 
     #[cfg(feature = "network-tests")]

--- a/crates/rgz-transport/src/actor.rs
+++ b/crates/rgz-transport/src/actor.rs
@@ -257,7 +257,9 @@ impl ActorZmqRuntime {
                                 &tx,
                                 metrics.as_ref(),
                                 InternalIoEvent::IoError {
-                                    error: TransportError::TemporaryTransport(format!("request recv failed: {err}")),
+                                    error: TransportError::TemporaryTransport(format!(
+                                        "request recv failed: {err}"
+                                    )),
                                     request_id: None,
                                 },
                             );
@@ -551,39 +553,45 @@ fn decode_u64_frame(data: &[u8], cursor: &mut usize) -> Option<u64> {
 
 fn decode_incoming_message(message: ZmqMessage) -> Result<InternalIoEvent, TransportError> {
     if message.len() >= 2 {
-        let topic_frame = message
-            .get(0)
-            .ok_or_else(|| TransportError::Serialization("missing publish topic frame".to_string()))?;
+        let topic_frame = message.get(0).ok_or_else(|| {
+            TransportError::Serialization("missing publish topic frame".to_string())
+        })?;
         if let Ok(topic) = String::from_utf8(topic_frame.to_vec()) {
             let payload = message
                 .get(1)
-                .ok_or_else(|| TransportError::Serialization("missing publish payload frame".to_string()))?
+                .ok_or_else(|| {
+                    TransportError::Serialization("missing publish payload frame".to_string())
+                })?
                 .to_vec();
             return Ok(InternalIoEvent::IncomingPublish { topic, payload });
         }
     }
 
-    let data: Vec<u8> = message
-        .try_into()
-        .map_err(|err: &str| TransportError::Serialization(format!("decode zmq message failed: {err}")))?;
+    let data: Vec<u8> = message.try_into().map_err(|err: &str| {
+        TransportError::Serialization(format!("decode zmq message failed: {err}"))
+    })?;
     if data.is_empty() {
-        return Err(TransportError::Serialization("empty zmq message".to_string()));
+        return Err(TransportError::Serialization(
+            "empty zmq message".to_string(),
+        ));
     }
 
     let mut cursor = 0usize;
     match data[0] {
         IO_FRAME_PUBLISH => {
             cursor += 1;
-            let topic_len = decode_u32_frame(&data, &mut cursor)
-                .ok_or_else(|| TransportError::Serialization("invalid publish frame".to_string()))?;
+            let topic_len = decode_u32_frame(&data, &mut cursor).ok_or_else(|| {
+                TransportError::Serialization("invalid publish frame".to_string())
+            })?;
             let topic_end = cursor + topic_len as usize;
             if topic_end > data.len() {
                 return Err(TransportError::Serialization(
                     "invalid publish topic length".to_string(),
                 ));
             }
-            let topic = String::from_utf8(data[cursor..topic_end].to_vec())
-                .map_err(|_| TransportError::Serialization("invalid publish topic utf8".to_string()))?;
+            let topic = String::from_utf8(data[cursor..topic_end].to_vec()).map_err(|_| {
+                TransportError::Serialization("invalid publish topic utf8".to_string())
+            })?;
             cursor = topic_end;
             let payload_len = decode_u32_frame(&data, &mut cursor).ok_or_else(|| {
                 TransportError::Serialization("invalid publish payload length".to_string())
@@ -610,8 +618,9 @@ fn decode_incoming_message(message: ZmqMessage) -> Result<InternalIoEvent, Trans
                     "invalid request topic length".to_string(),
                 ));
             }
-            let topic = String::from_utf8(data[cursor..topic_end].to_vec())
-                .map_err(|_| TransportError::Serialization("invalid request topic utf8".to_string()))?;
+            let topic = String::from_utf8(data[cursor..topic_end].to_vec()).map_err(|_| {
+                TransportError::Serialization("invalid request topic utf8".to_string())
+            })?;
             cursor = topic_end;
             let payload_len = decode_u32_frame(&data, &mut cursor).ok_or_else(|| {
                 TransportError::Serialization("invalid request payload length".to_string())
@@ -634,7 +643,9 @@ fn decode_incoming_message(message: ZmqMessage) -> Result<InternalIoEvent, Trans
             let request_id = decode_u64_frame(&data, &mut cursor)
                 .ok_or_else(|| TransportError::Serialization("invalid reply id".to_string()))?;
             if data.len().saturating_sub(cursor) < 1 {
-                return Err(TransportError::Serialization("invalid reply status".to_string()));
+                return Err(TransportError::Serialization(
+                    "invalid reply status".to_string(),
+                ));
             }
             let status = byte_to_status(data[cursor]);
             cursor += 1;
@@ -2597,13 +2608,17 @@ mod tests {
                 .await
                 .expect("publish command");
             if matches!(
-                recv_until(&mut subscriber.event_rx, Duration::from_millis(150), |event| {
-                    matches!(
-                        event,
-                        RxEvent::IncomingPublish { topic: event_topic, payload, .. }
-                            if event_topic == &topic && payload == b"recovered"
-                    )
-                })
+                recv_until(
+                    &mut subscriber.event_rx,
+                    Duration::from_millis(150),
+                    |event| {
+                        matches!(
+                            event,
+                            RxEvent::IncomingPublish { topic: event_topic, payload, .. }
+                                if event_topic == &topic && payload == b"recovered"
+                        )
+                    }
+                )
                 .await,
                 Some(RxEvent::IncomingPublish { .. })
             ) {

--- a/crates/rgz-transport/src/api.rs
+++ b/crates/rgz-transport/src/api.rs
@@ -42,8 +42,9 @@ impl Transport {
     pub async fn start(self) -> TransportResult<TransportHandle> {
         let next = {
             let state = self.state.lock().await;
-            transition(*state, TransportEvent::InitRequested)
-                .map_err(|_| TransportError::invalid_transition(*state, TransportEvent::InitRequested))?
+            transition(*state, TransportEvent::InitRequested).map_err(|_| {
+                TransportError::invalid_transition(*state, TransportEvent::InitRequested)
+            })?
         };
 
         {
@@ -361,13 +362,11 @@ mod tests {
         assert_eq!(ok_count, 1);
         assert!(matches!(
             first,
-            Ok(())
-                | Err(TransportError::InvalidState { .. })
+            Ok(()) | Err(TransportError::InvalidState { .. })
         ));
         assert!(matches!(
             second,
-            Ok(())
-                | Err(TransportError::InvalidState { .. })
+            Ok(()) | Err(TransportError::InvalidState { .. })
         ));
 
         assert_eq!(handle.state().await, TransportState::Stopped);

--- a/crates/rgz-transport/src/error.rs
+++ b/crates/rgz-transport/src/error.rs
@@ -67,10 +67,12 @@ mod tests {
 
     #[test]
     fn non_retryable_errors_are_classified() {
-        assert!(!TransportError::InvalidState {
-            detail: "bad state".to_string(),
-        }
-        .is_retryable());
+        assert!(
+            !TransportError::InvalidState {
+                detail: "bad state".to_string(),
+            }
+            .is_retryable()
+        );
         assert!(!TransportError::Serialization("decode".to_string()).is_retryable());
         assert!(!TransportError::Internal("panic".to_string()).is_retryable());
     }

--- a/docs/transport-v2-reconnect-lifecycle.md
+++ b/docs/transport-v2-reconnect-lifecycle.md
@@ -1,0 +1,21 @@
+# Transport v2 reconnect lifecycle
+
+`TxCmd::Connect` and `TxCmd::Disconnect` are actor commands. The actor owns a mutable endpoint
+configuration, rather than allowing socket tasks to retain independent endpoint state.
+
+## Lifecycle
+
+1. `Disconnect` removes the endpoint from the runtime's PUB, SUB, and DEALER connection lists.
+2. The actor stops the SUB and DEALER receive tasks and drops the PUB and DEALER send halves.
+3. The actor recreates the runtime from the updated configuration and restores all subscriptions.
+4. `Connect` adds the endpoint to the same connection lists and repeats the rebuild.
+
+The endpoint-only public command deliberately applies to all client socket roles because it has no
+socket-role parameter. Bind endpoints remain immutable construction-time configuration.
+
+## Errors and shutdown
+
+Socket creation or subscription restoration failures are emitted as retryable transport errors and
+move the state machine to `Degraded`. A later successful connect, send, or receive transitions the
+state back to `Running`. Shutdown uses the same task-stop path and does not leave receive tasks
+running after the actor exits.


### PR DESCRIPTION
## Summary

- Rebuild the ZeroMQ PUB/SUB/DEALER runtime on connect and disconnect.
- Restore subscriptions after rebuilding receive tasks.
- Add lifecycle documentation and PUB/SUB plus request/reply network recovery tests.

## Why

Connect and disconnect previously emitted lifecycle events without changing live sockets, preventing recovery validation.

## Validation

- `cargo test -p rgz-transport`
- `cargo test -p rgz-transport --features network-tests zeromq_pub_sub_disconnect_then_reconnect_recovers_delivery -- --ignored`
- `cargo test -p rgz-transport --features network-tests zeromq_request_reply_disconnect_then_reconnect_recovers_delivery -- --ignored`